### PR TITLE
Dispatch events synchronously

### DIFF
--- a/src/Events/EmbeddingAvailable.php
+++ b/src/Events/EmbeddingAvailable.php
@@ -6,12 +6,12 @@ use Biigle\Broadcasting\UserChannel;
 use Biigle\User;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Storage;
 
-class EmbeddingAvailable implements ShouldBroadcast
+class EmbeddingAvailable implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/Events/EmbeddingAvailable.php
+++ b/src/Events/EmbeddingAvailable.php
@@ -52,7 +52,6 @@ class EmbeddingAvailable implements ShouldBroadcastNow
      */
     public function __construct($filename, User $user)
     {
-        $this->queue = config('magic_sam.broadcast_queue');
         $this->filename = $filename;
         $this->user = $user;
     }

--- a/src/Events/EmbeddingFailed.php
+++ b/src/Events/EmbeddingFailed.php
@@ -44,7 +44,6 @@ class EmbeddingFailed implements ShouldBroadcastNow
      */
     public function __construct(User $user)
     {
-        $this->queue = config('magic_sam.broadcast_queue');
         $this->user = $user;
     }
 

--- a/src/Events/EmbeddingFailed.php
+++ b/src/Events/EmbeddingFailed.php
@@ -6,11 +6,11 @@ use Biigle\Broadcasting\UserChannel;
 use Biigle\User;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class EmbeddingFailed implements ShouldBroadcast
+class EmbeddingFailed implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/config/magic_sam.php
+++ b/src/config/magic_sam.php
@@ -86,11 +86,6 @@ return [
     'model_path' => storage_path('magic_sam').'/sam_checkpoint.pth',
 
     /*
-     | Specifies which queue should be used for the broadcast events.
-     */
-    'broadcast_queue' => env('MAGIC_SAM_BROADCAST_QUEUE', 'default'),
-
-    /*
      | Specifies the time in days after which an image embedding file will be deleted
      | again.
      */


### PR DESCRIPTION
Resolves #3 by using shouldBroadcastNow

Class shouldBroadcast uses default queue which can lead to delayed event dispatching when the queue is busy.
Use shouldBroadcastNow to dispatch events immediately.